### PR TITLE
Enable wtf command

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -5,6 +5,7 @@ from Legobot.Lego import Lego
 from Local.Roll import Roll
 from Local.Msync import Audit
 from Local.Puppet3 import Puppet3
+from Local.WikipediaTopFinder import WikipediaTopFinder
 
 from Legobot.Connectors.IRC import IRC
 from Legobot.Legos.Help import Help
@@ -40,3 +41,4 @@ baseplate_proxy.add_child(Help)
 baseplate_proxy.add_child(Roll)
 baseplate_proxy.add_child(Audit)
 baseplate_proxy.add_child(Puppet3)
+baseplate_proxy.add_child(WikipediaTopFinder)


### PR DESCRIPTION
Turn on the WikipediaTopFinder lego, allowing wikipedia searches via the `!wtf` command.