### PR TITLE
systemd user units don't use system; use default.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ExecStart=/home/$USER/thevoxfox/venv/bin/python3 /home/$USER/thevoxfox/chatbot.p
 PrivateTmp=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
 You can now start/stop/restart/status the bot with:


### PR DESCRIPTION
User units can not reference or depend on system units.
For clarification: `man 7 systemd.special | sed -n '351,354'p $1`