### PR TITLE
bump legos.wtf to 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ semver==2.7.2
 pyflakes==1.3.0
 bandit==1.3.0
 legos.xkcd==0.1.1
-legos.wtf==0.1.2
+legos.wtf==0.1.3
 legos.stocks==0.1.0
 legos.codinglove==0.1.0
 legos.dice==0.1.0


### PR DESCRIPTION
0.1.2 is broken:
    Installing /home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/legos.wtf-0.1.2-py3.4-nspkg.pth
  Running setup.py install for legos.stocks
    /usr/lib/python3.4/distutils/dist.py:260: UserWarning: Unknown distribution option: 'descrption'
      warnings.warn(msg)
    Skipping installation of /home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/legos/__init__.py (namespace package)