### PR TITLE
Missing legos.devopsy from requirements.txt - Defined in chatbot.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ legos.wtf==0.1.2
 legos.stocks==0.1.0
 legos.codinglove==0.1.0
 legos.dice==0.1.0
+legos.devopsy==0.1.0


### PR DESCRIPTION
Fixes missing package.