### PR TITLE
add missing dependency lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Legobot==1.0.2
 semver==2.7.2
 pyflakes==1.3.0
 bandit==1.3.0
+lxml==3.7.1
 legos.xkcd==0.1.1
 legos.wtf==0.1.3
 legos.stocks==0.1.0


### PR DESCRIPTION
without it:
```log
(venv)bastelfreak@basteles-bastelknecht ~/thevoxfox $ python3 chatbot.py
Traceback (most recent call last):
  File "/home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/pyquery/__init__.py", line 8, in <module>
    import webob
ImportError: No module named 'webob'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "chatbot.py", line 10, in <module>
    from legos.devopsy import Devopsy
  File "/home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/legos/devopsy.py", line 5, in <module>
    from pyquery import PyQuery
  File "/home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/pyquery/__init__.py", line 11, in <module>
    from .pyquery import PyQuery
  File "/home/bastelfreak/thevoxfox/venv/lib/python3.4/site-packages/pyquery/pyquery.py", line 9, in <module>
    from lxml import etree
ImportError: No module named 'lxml'
(venv)bastelfreak@basteles-bastelknecht ~/thevoxfox $
```